### PR TITLE
feat: Add it naming rector

### DIFF
--- a/config/sets/pest-code-quality.php
+++ b/config/sets/pest-code-quality.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Pest\Rector\FuncCall\PestItNamingRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rules([
+        PestItNamingRector::class,
+    ]);
+};

--- a/src/Rector/FuncCall/PestItNamingRector.php
+++ b/src/Rector/FuncCall/PestItNamingRector.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Pest\Rector\FuncCall;
+
+use Nette\Utils\Strings;
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Pest\Tests\Rector\FuncCall\PestItNamingRector\PestItNamingRectorTest
+ */
+final class PestItNamingRector extends AbstractRector implements DocumentedRuleInterface
+{
+    /** @var string */
+    private const KEYWORD = 'it';
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Renames tests starting with `it` to use the `it()` function', [
+            new CodeSample(
+                <<<'PHP'
+test('it starts with it')->skip();
+PHP,
+                <<<'PHP'
+it('starts with it')->skip();
+PHP
+            ),
+        ]);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    /**
+     * @param FuncCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isNames($node, ['test', 'it'])) {
+            return null;
+        }
+
+        $args = (array) $node->args;
+        if (count($args) === 0) {
+            return null;
+        }
+
+        $firstArgument = $args[0];
+
+        if (!$firstArgument instanceof Node\Arg) {
+            return null;
+        }
+
+        $value = $firstArgument->value;
+        if (!$value instanceof String_) {
+            return null;
+        }
+
+        $firstArgumentValue = $value->value;
+
+        if (! Strings::startsWith($firstArgumentValue, self::KEYWORD)) {
+            return null;
+        }
+
+        $node->name = new Name(self::KEYWORD);
+        $firstArgument->value = new String_(trim(substr($firstArgumentValue, strlen(self::KEYWORD))));
+
+        return $node;
+    }
+}

--- a/src/Set/PestSetList.php
+++ b/src/Set/PestSetList.php
@@ -12,4 +12,9 @@ final class PestSetList implements SetListInterface
      * @var string
      */
     public const PHPUNIT_TO_PEST = __DIR__ . '/../../config/sets/phpunit-to-pest.php';
+
+    /**
+     * @var string
+     */
+    public const CODE_QUALITY = __DIR__ . '/../../config/sets/pest-code-quality.php';
 }

--- a/tests/Rector/FuncCall/PestItNamingRector/Fixture/rename_test_starting_with_it_in_name.php.inc
+++ b/tests/Rector/FuncCall/PestItNamingRector/Fixture/rename_test_starting_with_it_in_name.php.inc
@@ -1,0 +1,27 @@
+<?php
+it('it can test', function () {
+    $this->assertTrue(true);
+});
+
+it('it can also test')->assertTrue(true);
+
+test('it does something', function () {
+    $this->assertTrue(true);
+});
+
+test('it also works')->assertTrue(true);
+?>
+-----
+<?php
+it('can test', function () {
+    $this->assertTrue(true);
+});
+
+it('can also test')->assertTrue(true);
+
+it('does something', function () {
+    $this->assertTrue(true);
+});
+
+it('also works')->assertTrue(true);
+?>

--- a/tests/Rector/FuncCall/PestItNamingRector/Fixture/skip_test_without_it_in_name.php.inc
+++ b/tests/Rector/FuncCall/PestItNamingRector/Fixture/skip_test_without_it_in_name.php.inc
@@ -1,0 +1,13 @@
+<?php
+it()->assertTrue(true);
+
+it('does something', function () {
+    $this->assertTrue(true);
+});
+
+test('does something', function () {
+    $this->assertTrue(true);
+});
+
+test()->assertTrue(true);
+?>

--- a/tests/Rector/FuncCall/PestItNamingRector/PestItNamingRectorTest.php
+++ b/tests/Rector/FuncCall/PestItNamingRector/PestItNamingRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Pest\Tests\Rector\FuncCall\PestItNamingRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class PestItNamingRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/FuncCall/PestItNamingRector/config/configured_rule.php
+++ b/tests/Rector/FuncCall/PestItNamingRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Pest\Rector\FuncCall\PestItNamingRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(PestItNamingRector::class);
+};


### PR DESCRIPTION
Adds a rector for changing tests to using the `it` naming schema if the name of the test suggest that was the purpose of it. 


Ported from Drift